### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/github-data.ipynb
+++ b/github-data.ipynb
@@ -303,7 +303,7 @@
     "\n",
     "We can figure this out by grouping by username, then summing the number of commits from every push, for each user. More technically speaking, we want to `GroupBy` on usernames, so for each username we get a list their of PushEvents. Then reduce each `PushEvent` by taking a `count` of their commits. Then reducing these `count`s by `sum`ing them for each user. So we are grouping then reducing.\n",
     "\n",
-    "However there are algorithms for grouping and reducing simultaneously which avoid expensive shuffle operations and are much faster. In dask bag we have `foldby`. Analogous methods: [`toolz.reduceby`]( http://toolz.readthedocs.org/en/latest/api.html#toolz.itertoolz.reduceby), and in pyspark [`RDD.combineByKey`](https://spark.apache.org/docs/latest/api/python/pyspark.html?#pyspark.RDD.combineByKey)."
+    "However there are algorithms for grouping and reducing simultaneously which avoid expensive shuffle operations and are much faster. In dask bag we have `foldby`. Analogous methods: [`toolz.reduceby`]( https://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.reduceby), and in pyspark [`RDD.combineByKey`](https://spark.apache.org/docs/latest/api/python/pyspark.html?#pyspark.RDD.combineByKey)."
    ]
   },
   {

--- a/github-on-ec2.ipynb
+++ b/github-on-ec2.ipynb
@@ -20,7 +20,7 @@
     "acluster open notebook  # open ipython-notebook in the browser to interact with the cluster\n",
     "```\n",
     "\n",
-    "While dask.distributed is well integrated with [Anaconda cluster](http://continuumio.github.io/anaconda-cluster/) it isn't restricted to it.  [This blogpost](http://matthewrocklin.com/blog/work/2015/06/23/Distributed/) shows how to set up a dask.distributed network manually and [these docs](http://dask.readthedocs.org/en/latest/distributed.html#ipython-parallel) show how to set up dask.distributed from any IPyParallel cluster.\n",
+    "While dask.distributed is well integrated with [Anaconda cluster](http://continuumio.github.io/anaconda-cluster/) it isn't restricted to it.  [This blogpost](http://matthewrocklin.com/blog/work/2015/06/23/Distributed/) shows how to set up a dask.distributed network manually and [these docs](https://dask.readthedocs.io/en/latest/distributed.html#ipython-parallel) show how to set up dask.distributed from any IPyParallel cluster.\n",
     "\n",
     "### Related Projects\n",
     "Projects for python analytics in a distributed memory environment\n",
@@ -280,7 +280,7 @@
     "\n",
     "We can figure this out by grouping by username, then summing the number of commits from every push, for each user. More technically speaking, we want to `GroupBy` on usernames, so for each username we get a list their of PushEvents. Then reduce each `PushEvent` by taking a `count` of their commits. Then reducing these `count`s by `sum`ing them for each user. So we are grouping then reducing.\n",
     "\n",
-    "However there are algorithms for grouping and reducing simultaneously which avoid expensive shuffle operations and are much faster. In dask bag we have `foldby`. Analogous methods: [`toolz.reduceby`]( http://toolz.readthedocs.org/en/latest/api.html#toolz.itertoolz.reduceby), and in pyspark [`RDD.combineByKey`](https://spark.apache.org/docs/latest/api/python/pyspark.html?#pyspark.RDD.combineByKey)."
+    "However there are algorithms for grouping and reducing simultaneously which avoid expensive shuffle operations and are much faster. In dask bag we have `foldby`. Analogous methods: [`toolz.reduceby`]( https://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.reduceby), and in pyspark [`RDD.combineByKey`](https://spark.apache.org/docs/latest/api/python/pyspark.html?#pyspark.RDD.combineByKey)."
    ]
   },
   {


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
